### PR TITLE
exclude garbage files from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('speedcord/values.py') as f:
 setup(
     name='speedcord',
     version=version,
-    packages=find_packages(),
+    packages=find_packages(["README.md", "setup.py", "speedcord/*"]),
     url='https://github.com/tag-epic/speedcord',
     license='MIT',
     author='Epic',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('speedcord/values.py') as f:
 setup(
     name='speedcord',
     version=version,
-    packages=find_packages(["README.md", "setup.py", "speedcord/*"]),
+    packages=find_packages(include=["README.md", "setup.py", "speedcord/*"]),
     url='https://github.com/tag-epic/speedcord',
     license='MIT',
     author='Epic',


### PR DESCRIPTION
This PR adds the following list of patterns explicitly to the `find_packages` call during setup, in order to exclude unnecessary files from the packaged build:

- setup.py
- speedcord/*
- README.md

This PR closes #5 