### PR TITLE
Comparisons to types - PEP8 style guide

### DIFF
--- a/speedcord/client.py
+++ b/speedcord/client.py
@@ -140,9 +140,9 @@ class Client:
         """
 
         def get_func(func):
-            if type(event) == int:
+            if isinstance(event, int):
                 self.opcode_dispatcher.register(event, func)
-            elif type(event) == str:
+            elif isinstance(event, str):
                 self.event_dispatcher.register(event, func)
             else:
                 raise TypeError("Invalid event type!")


### PR DESCRIPTION
* Code based on [PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/)

> Object type comparisons should always use isinstance() instead of comparing types directly